### PR TITLE
Compact resulting XML

### DIFF
--- a/lib/IdP/ADFS.php
+++ b/lib/IdP/ADFS.php
@@ -138,7 +138,7 @@ MSG;
 </wst:RequestSecurityTokenResponse>
 MSG;
 
-        return $result;
+    return trim(preg_replace('/^\s+|\r|\n/m', '', $result));
     }
 
 


### PR DESCRIPTION
Formatted XML is good to read by humans but not so good for systems. This request is to address an issue at relying party being .NET Core / .NET 5 web app when SimpleSAMLphp STS is hosted under Windows.

MS-based solutions are main beneficients of WS-Fed. However they get crazy if an XML payload from STS contains newline characters, especially CR. They see CR as an actual XML entity what effectively prevents the whole payload from further processing - throws exception. Compacting the XML at STS can help to solve that without any risk.

Here in company we have another STS that is based on DirX Access. It produces compact XML by default so we have never had issues with that. We also use this modified version of SimpleSAMLphp STS on one of our productions so it well-tested over there.