### PR TITLE
Adapt to similar changes in SSP master

### DIFF
--- a/src/IdP/ADFS.php
+++ b/src/IdP/ADFS.php
@@ -118,6 +118,8 @@ MSG;
                 $name,
                 'http://schemas.xmlsoap.org/claims'
             );
+            $namespace = htmlspecialchars($namespace);
+            $name = htmlspecialchars($name);
             foreach ($values as $value) {
                 if ((!isset($value)) || ($value === '')) {
                     continue;

--- a/tests/src/Controller/AdfsControllerTest.php
+++ b/tests/src/Controller/AdfsControllerTest.php
@@ -86,8 +86,7 @@ class AdfsControllerTest extends TestCase
         $c = new Controller\Adfs($this->config, $this->session);
 
         $this->expectException(Error\MetadataNotFound::class);
-        // This line breaks tests in PHP 8.1
-        //$this->expectExceptionMessage("METADATANOTFOUND('%ENTITYID%' => '\'urn:example-sp\'')");
+        $this->expectExceptionMessage("METADATANOTFOUND('%ENTITYID%' => 'urn:example-sp')");
 
         $c->prp($request);
     }


### PR DESCRIPTION
htmlentities is not done in utils, needs to be done when creating the output (here).

format=xhtml has been removed from master.

Broken test was fixed