### PR TITLE
A hook to generate metadata

### DIFF
--- a/hooks/hook_generate_metadata.php
+++ b/hooks/hook_generate_metadata.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use SimpleSAML\Assert\Assert;
+use SimpleSAML\SAML2\Constants as C;
+use SimpleSAML\{Configuration, Utils, Logger, Module};
+use SimpleSAML\Locale\Translate;
+use SimpleSAML\Metadata\MetaDataStorageHandler;
+
+function adfs_hook_generate_metadata(array &$hookinfo): void
+{
+    if( $hookinfo['set'] == 'adfs-idp-hosted' ) {
+
+        $property = $hookinfo['property'];
+        $endpoint = Module::getModuleURL('adfs/idp/prp.php');
+        switch ($property) {
+            case 'SingleSignOnService':
+                $hookinfo['result'] = $endpoint;
+                break;
+                
+            case 'SingleSignOnServiceBinding':
+                $hookinfo['result'] = C::BINDING_HTTP_REDIRECT;
+                break;
+                
+            case 'SingleLogoutService':
+                $hookinfo['result'] = $endpoint;
+                break;
+                
+            case 'SingleLogoutServiceBinding':
+                $hookinfo['result'] = C::BINDING_HTTP_REDIRECT;
+                break;
+        }
+    }
+}
+


### PR DESCRIPTION
This update allows the main SSP library to not have to know about the adfs-idp-hosted set and how to handle it.

The hook could make a new object and register it with MetaDataStorageHandler for use there but it seems like a bit of overkill for 4 strings. It is also possible to evolve to a class for this if desired or other modules are wanting to make more extensive use of a `getGenerated` hook.